### PR TITLE
Simplified YAML + layer catalog

### DIFF
--- a/dark-matter-all.yml
+++ b/dark-matter-all.yml
@@ -1,156 +1,27 @@
-_layer_default: &layer
-  type: mapnik
-
-_options_default: &options
-  cartocss_version: 2.1.1
-
 name: DarkMatter-all
-version: 0.0.1
-layergroup:
-  version: 1.0.1
-  minzoom: 0
-  maxzoom: 20
+minzoom: 0
+maxzoom: 20
 
-  layers:
-    # TODO merge options into layer to facilitate easier inclusion of external nodes
-    - <<: *layer
-      name: global_variables
-      options:
-        <<: *options
-        cartocss_file: styles/global_variables_dark.mss
-        sql: |
-          SELECT null::geometry AS the_geom_webmercator LIMIT 0
-    - <<: *layer
-      name: false_background
-      options:
-        <<: *options
-        sql: |
-          SELECT the_geom_webmercator
-          FROM false_background_zoomed('!scale_denominator!', !bbox!) AS _
-    - <<: *layer
-      name: land_positive
-      options:
-        <<: *options
-        sql: |
-          SELECT
-            cartodb_id,
-            the_geom_webmercator
-          FROM land_positive_zoomed('!scale_denominator!', !bbox!) AS _
-    - <<: *layer
-      name: urban_areas
-      options:
-        <<: *options
-        sql: |
-          SELECT
-            cartodb_id,
-            scalerank,
-            the_geom_webmercator
-          FROM urban_areas_zoomed('!scale_denominator!',!bbox!) AS _
-    - <<: *layer
-      name: green_areas
-      options:
-        <<: *options
-        sql: |
-          SELECT osm_id, the_geom_webmercator, area FROM green_areas_zoomed('planet_green','!scale_denominator!',!bbox!) AS _
-    - <<: *layer
-      name: admin0boundaries
-      options:
-        <<: *options
-        sql: |
-          SELECT cartodb_id, the_geom_webmercator, unit FROM admin0boundaries_zoomed('planet_green','!scale_denominator!', !bbox!) AS _
-    - <<: *layer
-      name: admin1boundaries
-      options:
-        <<: *options
-        sql: |
-          SELECT cartodb_id, scalerank, the_geom_webmercator FROM admin1boundaries_zoomed('planet_green','!scale_denominator!', !bbox!) AS _
-    - <<: *layer
-      name: water
-      options:
-        <<: *options
-        sql: |
-          (SELECT id, the_geom_webmercator, name, type, is_lake, ne_scalerank, area FROM water_zoomed('planet_green','!scale_denominator!', !bbox!) AS _) UNION (SELECT cartodb_id, the_geom_webmercator, '' AS name, 'ocean' AS type, 1 AS is_lake, 0 AS ne_scalerank, 999999999 AS area FROM land_negative_zoomed('!scale_denominator!', !bbox!) AS _)
-    - <<: *layer
-      name: aeroways
-      options:
-        <<: *options
-        sql: |
-          SELECT osm_id, type, the_geom_webmercator FROM aeroways_zoomed('planet_green','!scale_denominator!', !bbox!) AS _
-    - <<: *layer
-      name: ne10mroads
-      options:
-        <<: *options
-        sql: |
-          SELECT cartodb_id, the_geom_webmercator, type, scalerank FROM ne_10m_roads_zoomed('!scale_denominator!', !bbox!) AS _
-    - <<: *layer
-      name: buildings
-      options:
-        <<: *options
-        sql: |
-          SELECT osm_id, the_geom_webmercator, area FROM buildings_zoomed('planet_green','!scale_denominator!',!bbox!) AS _
-    - <<: *layer
-      name: osmtunnels
-      options:
-        <<: *options
-        sql: |
-          select highway, railway, kind, the_geom_webmercator, is_link from tunnels('planet_green','!scale_denominator!',!bbox!) as _
-    - <<: *layer
-      name: osmroads
-      options:
-        <<: *options
-        sql: |
-          select highway, railway, kind, the_geom_webmercator, is_link from high_road('planet_green','!scale_denominator!',!bbox!) as _
-    - <<: *layer
-      name: osmbridges
-      options:
-        <<: *options
-        sql: |
-          select highway, railway, kind, the_geom_webmercator, is_link from bridges('planet_green','!scale_denominator!',!bbox!) as _
-    - <<: *layer
-      name: country_city_labels
-      options:
-        <<: *options
-        sql: |
-          SELECT cartodb_id, name, the_geom_webmercator, scalerank, place, pop_est, country_city, is_capital FROM country_city_labels_zoomed('planet_green','!scale_denominator!',!bbox!) AS _
-    - <<: *layer
-      name: park_labels
-      options:
-        <<: *options
-        sql: |
-          SELECT osm_id, name, area, the_geom_webmercator FROM green_areas_zoomed('planet_green','!scale_denominator!',!bbox!) AS _
-    - <<: *layer
-      name: water_labels
-      options:
-        <<: *options
-        sql: |
-          SELECT id, the_geom_webmercator, name, area, is_lake FROM water_zoomed('planet_green','!scale_denominator!',!bbox!) AS _
-    - <<: *layer
-      name: osm_roads_labels
-      options:
-        <<: *options
-        sql: |
-          SELECT name, highway, railway, kind, the_geom_webmercator FROM high_road_labels('planet_green','!scale_denominator!',!bbox!) as _
-    - <<: *layer
-      name: marine_labels
-      options:
-        <<: *options
-        sql: |
-          SELECT cartodb_id, name, namealt, featurecla, the_geom_webmercator, scalerank FROM ne_marine_zoomed('!scale_denominator!',!bbox!) AS _
-    - <<: *layer
-      name: admin1boundary_labels
-      options:
-        <<: *options
-        sql: |
-          SELECT cartodb_id, name, scalerank, the_geom_webmercator, geomtype from admin1boundaries_zoomed('planet_green','!scale_denominator!',!bbox!) as _
-    - <<: *layer
-      name: admin1_labels
-      options:
-        <<: *options
-        sql: |
-          SELECT cartodb_id, name, scalerank, the_geom_webmercator FROM admin1_polygons_zoomed('!scale_denominator!',!bbox!) AS _
-    - <<: *layer
-      name: continent_labels
-      options:
-        <<: *options
-        sql: |
-          SELECT cartodb_id, name, the_geom_webmercator FROM continents_zoomed('!scale_denominator!',!bbox!) AS _
+layers:
+  - global_variables: styles/global_variables_dark.mss
+  - false_background:
+  - land_positive:
+  - urban_areas:
+  - green_areas:
+  - admin0boundaries:
+  - admin1boundaries:
+  - water:
+  - aeroways:
+  - ne10mroads:
+  - buildings:
+  - osmtunnels:
+  - osmroads:
+  - osmbridges:
+  - country_city_labels:
+  - park_labels:
+  - water_labels:
+  - osm_roads_labels:
+  - marine_labels:
+  - admin1boundary_labels:
+  - admin1_labels:
+  - continent_labels:

--- a/dark-matter-labels-only.yml
+++ b/dark-matter-labels-only.yml
@@ -1,70 +1,14 @@
-_layer_default: &layer
-  type: mapnik
-
-_options_default: &options
-  cartocss_version: 2.1.1
-
 name: DarkMatter-labels-only
-version: 0.0.1
-layergroup:
-  version: 1.0.1
-  minzoom: 0
-  maxzoom: 20
+minzoom: 0
+maxzoom: 20
 
-  layers:
-    # TODO merge options into layer to facilitate easier inclusion of external nodes
-    - <<: *layer
-      name: global_variables
-      options:
-        <<: *options
-        cartocss_file: styles/global_variables_dark_only_labels.mss
-        sql: |
-          SELECT null::geometry AS the_geom_webmercator LIMIT 0
-    - <<: *layer
-      name: country_city_labels
-      options:
-        <<: *options
-        sql: |
-          SELECT cartodb_id, name, the_geom_webmercator, scalerank, place, pop_est, country_city, is_capital FROM country_city_labels_zoomed('planet_green','!scale_denominator!',!bbox!) AS _
-    - <<: *layer
-      name: park_labels
-      options:
-        <<: *options
-        sql: |
-          SELECT osm_id, name, area, the_geom_webmercator FROM green_areas_zoomed('planet_green','!scale_denominator!',!bbox!) AS _
-    - <<: *layer
-      name: water_labels
-      options:
-        <<: *options
-        sql: |
-          SELECT id, the_geom_webmercator, name, area, is_lake FROM water_zoomed('planet_green','!scale_denominator!',!bbox!) AS _
-    - <<: *layer
-      name: osm_roads_labels
-      options:
-        <<: *options
-        sql: |
-          SELECT name, highway, railway, kind, the_geom_webmercator FROM high_road_labels('planet_green','!scale_denominator!',!bbox!) as _
-    - <<: *layer
-      name: marine_labels
-      options:
-        <<: *options
-        sql: |
-          SELECT cartodb_id, name, namealt, featurecla, the_geom_webmercator, scalerank FROM ne_marine_zoomed('!scale_denominator!',!bbox!) AS _
-    - <<: *layer
-      name: admin1boundary_labels
-      options:
-        <<: *options
-        sql: |
-          SELECT cartodb_id, name, scalerank, the_geom_webmercator, geomtype from admin1boundaries_zoomed('planet_green','!scale_denominator!',!bbox!) as _
-    - <<: *layer
-      name: admin1_labels
-      options:
-        <<: *options
-        sql: |
-          SELECT cartodb_id, name, scalerank, the_geom_webmercator FROM admin1_polygons_zoomed('!scale_denominator!',!bbox!) AS _
-    - <<: *layer
-      name: continent_labels
-      options:
-        <<: *options
-        sql: |
-          SELECT cartodb_id, name, the_geom_webmercator FROM continents_zoomed('!scale_denominator!',!bbox!) AS _
+layers:
+  - global_variables:  styles/global_variables_dark_only_labels.mss
+  - country_city_labels:
+  - park_labels:
+  - water_labels:
+  - osm_roads_labels:
+  - marine_labels:
+  - admin1boundary_labels:
+  - admin1_labels:
+  - continent_labels:

--- a/dark-matter-no-labels.yml
+++ b/dark-matter-no-labels.yml
@@ -1,108 +1,19 @@
-_layer_default: &layer
-  type: mapnik
-
-_options_default: &options
-  cartocss_version: 2.1.1
-
 name: DarkMatter-no-labels
-version: 0.0.1
-layergroup:
-  version: 1.0.1
-  minzoom: 0
-  maxzoom: 20
+minzoom: 0
+maxzoom: 20
 
-  layers:
-    # TODO merge options into layer to facilitate easier inclusion of external nodes
-    - <<: *layer
-      name: global_variables
-      options:
-        <<: *options
-        cartocss_file: styles/global_variables_dark.mss
-        sql: |
-          SELECT null::geometry AS the_geom_webmercator LIMIT 0
-    - <<: *layer
-      name: false_background
-      options:
-        <<: *options
-        sql: |
-          SELECT the_geom_webmercator
-          FROM false_background_zoomed('!scale_denominator!', !bbox!) AS _
-    - <<: *layer
-      name: land_positive
-      options:
-        <<: *options
-        sql: |
-          SELECT
-            cartodb_id,
-            the_geom_webmercator
-          FROM land_positive_zoomed('!scale_denominator!', !bbox!) AS _
-    - <<: *layer
-      name: urban_areas
-      options:
-        <<: *options
-        sql: |
-          SELECT
-            cartodb_id,
-            scalerank,
-            the_geom_webmercator
-          FROM urban_areas_zoomed('!scale_denominator!',!bbox!) AS _
-    - <<: *layer
-      name: green_areas
-      options:
-        <<: *options
-        sql: |
-          SELECT osm_id, the_geom_webmercator, area FROM green_areas_zoomed('planet_green','!scale_denominator!',!bbox!) AS _
-    - <<: *layer
-      name: admin0boundaries
-      options:
-        <<: *options
-        sql: |
-          SELECT cartodb_id, the_geom_webmercator, unit FROM admin0boundaries_zoomed('planet_green','!scale_denominator!', !bbox!) AS _
-    - <<: *layer
-      name: admin1boundaries
-      options:
-        <<: *options
-        sql: |
-          SELECT cartodb_id, scalerank, the_geom_webmercator FROM admin1boundaries_zoomed('planet_green','!scale_denominator!', !bbox!) AS _
-    - <<: *layer
-      name: water
-      options:
-        <<: *options
-        sql: |
-          (SELECT id, the_geom_webmercator, name, type, is_lake, ne_scalerank, area FROM water_zoomed('planet_green','!scale_denominator!', !bbox!) AS _) UNION (SELECT cartodb_id, the_geom_webmercator, '' AS name, 'ocean' AS type, 1 AS is_lake, 0 AS ne_scalerank, 999999999 AS area FROM land_negative_zoomed('!scale_denominator!', !bbox!) AS _)
-    - <<: *layer
-      name: aeroways
-      options:
-        <<: *options
-        sql: |
-          SELECT osm_id, type, the_geom_webmercator FROM aeroways_zoomed('planet_green','!scale_denominator!', !bbox!) AS _
-    - <<: *layer
-      name: ne10mroads
-      options:
-        <<: *options
-        sql: |
-          SELECT cartodb_id, the_geom_webmercator, type, scalerank FROM ne_10m_roads_zoomed('!scale_denominator!', !bbox!) AS _
-    - <<: *layer
-      name: buildings
-      options:
-        <<: *options
-        sql: |
-          SELECT osm_id, the_geom_webmercator, area FROM buildings_zoomed('planet_green','!scale_denominator!',!bbox!) AS _
-    - <<: *layer
-      name: osmtunnels
-      options:
-        <<: *options
-        sql: |
-          select highway, railway, kind, the_geom_webmercator, is_link from tunnels('planet_green','!scale_denominator!',!bbox!) as _
-    - <<: *layer
-      name: osmroads
-      options:
-        <<: *options
-        sql: |
-          select highway, railway, kind, the_geom_webmercator, is_link from high_road('planet_green','!scale_denominator!',!bbox!) as _
-    - <<: *layer
-      name: osmbridges
-      options:
-        <<: *options
-        sql: |
-          select highway, railway, kind, the_geom_webmercator, is_link from bridges('planet_green','!scale_denominator!',!bbox!) as _
+layers:
+  - global_variables: styles/global_variables_dark.mss
+  - false_background:
+  - land_positive:
+  - urban_areas:
+  - green_areas:
+  - admin0boundaries:
+  - admin1boundaries:
+  - water:
+  - aeroways:
+  - ne10mroads:
+  - buildings:
+  - osmtunnels:
+  - osmroads:
+  - osmbridges:

--- a/dark-matter.yml
+++ b/dark-matter.yml
@@ -1,141 +1,24 @@
-_layer_default: &layer
-  type: mapnik
-
-_options_default: &options
-  cartocss_version: 2.1.1
-
 name: DarkMatter
-version: 0.0.1
-placeholders:
-  color:
-    type: css_color
-    default: red
-  cartodb_id:
-    type: number
-    default: 1
-layergroup:
-  version: 1.0.1
-  minzoom: 0
-  maxzoom: 20
+minzoom: 0
+maxzoom: 20
 
-  layers:
-    # TODO merge options into layer to facilitate easier inclusion of external nodes
-    - <<: *layer
-      name: global_variables
-      options:
-        <<: *options
-        cartocss_file: styles/global_variables_dark.mss
-        sql: |
-          SELECT null::geometry AS the_geom_webmercator LIMIT 0
-    - <<: *layer
-      name: false_background
-      options:
-        <<: *options
-        sql: |
-          SELECT the_geom_webmercator
-          FROM false_background_zoomed('!scale_denominator!', !bbox!) AS _
-    - <<: *layer
-      name: land_positive
-      options:
-        <<: *options
-        sql: |
-          SELECT
-            cartodb_id,
-            the_geom_webmercator
-          FROM land_positive_zoomed('!scale_denominator!', !bbox!) AS _
-    - <<: *layer
-      name: admin0boundaries
-      options:
-        <<: *options
-        sql: |
-          SELECT cartodb_id, the_geom_webmercator, unit FROM admin0boundaries_zoomed('planet_green','!scale_denominator!', !bbox!) AS _
-    - <<: *layer
-      name: admin1boundaries
-      options:
-        <<: *options
-        sql: |
-          SELECT cartodb_id, scalerank, the_geom_webmercator FROM admin1boundaries_zoomed('planet_green','!scale_denominator!', !bbox!) AS _
-    - <<: *layer
-      name: water
-      options:
-        <<: *options
-        sql: |
-          (SELECT id, the_geom_webmercator, name, type, is_lake, ne_scalerank, area FROM water_zoomed('planet_green','!scale_denominator!', !bbox!) AS _) UNION (SELECT cartodb_id, the_geom_webmercator, '' AS name, 'ocean' AS type, 1 AS is_lake, 0 AS ne_scalerank, 999999999 AS area FROM land_negative_zoomed('!scale_denominator!', !bbox!) AS _)
-    - <<: *layer
-      name: aeroways
-      options:
-        <<: *options
-        sql: |
-          SELECT osm_id, type, the_geom_webmercator FROM aeroways_zoomed('planet_green','!scale_denominator!', !bbox!) AS _
-    - <<: *layer
-      name: ne10mroads
-      options:
-        <<: *options
-        sql: |
-          SELECT cartodb_id, the_geom_webmercator, type, scalerank FROM ne_10m_roads_zoomed('!scale_denominator!', !bbox!) AS _
-    - <<: *layer
-      name: osmtunnels
-      options:
-        <<: *options
-        sql: |
-          select highway, railway, kind, the_geom_webmercator, is_link from tunnels('planet_green','!scale_denominator!',!bbox!) as _
-    - <<: *layer
-      name: osmroads
-      options:
-        <<: *options
-        sql: |
-          select highway, railway, kind, the_geom_webmercator, is_link from high_road('planet_green','!scale_denominator!',!bbox!) as _
-    - <<: *layer
-      name: osmbridges
-      options:
-        <<: *options
-        sql: |
-          select highway, railway, kind, the_geom_webmercator, is_link from bridges('planet_green','!scale_denominator!',!bbox!) as _
-    - <<: *layer
-      name: country_city_labels
-      options:
-        <<: *options
-        sql: |
-          SELECT cartodb_id, name, the_geom_webmercator, scalerank, place, pop_est, country_city, is_capital FROM country_city_labels_zoomed('planet_green','!scale_denominator!',!bbox!) AS _
-    - <<: *layer
-      name: park_labels
-      options:
-        <<: *options
-        sql: |
-          SELECT osm_id, name, area, the_geom_webmercator FROM green_areas_zoomed('planet_green','!scale_denominator!',!bbox!) AS _
-    - <<: *layer
-      name: water_labels
-      options:
-        <<: *options
-        sql: |
-          SELECT id, the_geom_webmercator, name, area, is_lake FROM water_zoomed('planet_green','!scale_denominator!',!bbox!) AS _
-    - <<: *layer
-      name: osm_roads_labels
-      options:
-        <<: *options
-        sql: |
-          SELECT name, highway, railway, kind, the_geom_webmercator FROM high_road_labels('planet_green','!scale_denominator!',!bbox!) as _
-    - <<: *layer
-      name: marine_labels
-      options:
-        <<: *options
-        sql: |
-          SELECT cartodb_id, name, namealt, featurecla, the_geom_webmercator, scalerank FROM ne_marine_zoomed('!scale_denominator!',!bbox!) AS _
-    - <<: *layer
-      name: admin1boundary_labels
-      options:
-        <<: *options
-        sql: |
-          SELECT cartodb_id, name, scalerank, the_geom_webmercator, geomtype from admin1boundaries_zoomed('planet_green','!scale_denominator!',!bbox!) as _
-    - <<: *layer
-      name: admin1_labels
-      options:
-        <<: *options
-        sql: |
-          SELECT cartodb_id, name, scalerank, the_geom_webmercator FROM admin1_polygons_zoomed('!scale_denominator!',!bbox!) AS _
-    - <<: *layer
-      name: continent_labels
-      options:
-        <<: *options
-        sql: |
-          SELECT cartodb_id, name, the_geom_webmercator FROM continents_zoomed('!scale_denominator!',!bbox!) AS _
+layers:
+  - global_variables: styles/global_variables_dark.mss
+  - false_background:
+  - land_positive:
+  - admin0boundaries:
+  - admin1boundaries:
+  - water:
+  - aeroways:
+  - ne10mroads:
+  - osmtunnels:
+  - osmroads:
+  - osmbridges:
+  - country_city_labels:
+  - park_labels:
+  - water_labels:
+  - osm_roads_labels:
+  - marine_labels:
+  - admin1boundary_labels:
+  - admin1_labels:
+  - continent_labels:

--- a/layers.yml
+++ b/layers.yml
@@ -1,0 +1,104 @@
+toner:
+  type: http
+  urlTemplate: http://{s}.tile.stamen.com/toner/{z}/{x}/{y}.png
+  subdomains:
+    - a
+    - b
+    - c
+    - d
+
+global_variables:
+  sql: |
+    SELECT null::geometry AS the_geom_webmercator LIMIT 0
+
+false_background:
+  sql: |
+    SELECT the_geom_webmercator
+    FROM false_background_zoomed('!scale_denominator!', !bbox!) AS _
+
+land_positive:
+  sql: |
+    SELECT
+      cartodb_id,
+      the_geom_webmercator
+    FROM land_positive_zoomed('!scale_denominator!', !bbox!) AS _
+
+urban_areas:
+  sql: |
+    SELECT
+      cartodb_id,
+      scalerank,
+      the_geom_webmercator
+    FROM urban_areas_zoomed('!scale_denominator!',!bbox!) AS _
+
+green_areas:
+  sql: |
+    SELECT osm_id, the_geom_webmercator, area FROM green_areas_zoomed('planet_green','!scale_denominator!',!bbox!) AS _
+
+admin0boundaries:
+  sql: |
+    SELECT cartodb_id, the_geom_webmercator, unit FROM admin0boundaries_zoomed('planet_green','!scale_denominator!', !bbox!) AS _
+
+admin1boundaries:
+  sql: |
+    SELECT cartodb_id, scalerank, the_geom_webmercator FROM admin1boundaries_zoomed('planet_green','!scale_denominator!', !bbox!) AS _
+
+water:
+  sql: |
+    (SELECT id, the_geom_webmercator, name, type, is_lake, ne_scalerank, area FROM water_zoomed('planet_green','!scale_denominator!', !bbox!) AS _) UNION (SELECT cartodb_id, the_geom_webmercator, '' AS name, 'ocean' AS type, 1 AS is_lake, 0 AS ne_scalerank, 999999999 AS area FROM land_negative_zoomed('!scale_denominator!', !bbox!) AS _)
+
+aeroways:
+  sql: |
+    SELECT osm_id, type, the_geom_webmercator FROM aeroways_zoomed('planet_green','!scale_denominator!', !bbox!) AS _
+
+ne10mroads:
+  sql: |
+    SELECT cartodb_id, the_geom_webmercator, type, scalerank FROM ne_10m_roads_zoomed('!scale_denominator!', !bbox!) AS _
+
+buildings:
+  sql: |
+    SELECT osm_id, the_geom_webmercator, area FROM buildings_zoomed('planet_green','!scale_denominator!',!bbox!) AS _
+
+osmtunnels:
+  sql: |
+    select highway, railway, kind, the_geom_webmercator, is_link from tunnels('planet_green','!scale_denominator!',!bbox!) as _
+
+osmroads:
+  sql: |
+    select highway, railway, kind, the_geom_webmercator, is_link from high_road('planet_green','!scale_denominator!',!bbox!) as _
+
+osmbridges:
+  sql: |
+    select highway, railway, kind, the_geom_webmercator, is_link from bridges('planet_green','!scale_denominator!',!bbox!) as _
+
+country_city_labels:
+  sql: |
+    SELECT cartodb_id, name, the_geom_webmercator, scalerank, place, pop_est, country_city, is_capital FROM country_city_labels_zoomed('planet_green','!scale_denominator!',!bbox!) AS _
+
+park_labels:
+  sql: |
+    SELECT osm_id, name, area, the_geom_webmercator FROM green_areas_zoomed('planet_green','!scale_denominator!',!bbox!) AS _
+
+water_labels:
+  sql: |
+    SELECT id, the_geom_webmercator, name, area, is_lake FROM water_zoomed('planet_green','!scale_denominator!',!bbox!) AS _
+
+osm_roads_labels:
+  sql: |
+    SELECT name, highway, railway, kind, the_geom_webmercator FROM high_road_labels('planet_green','!scale_denominator!',!bbox!) as _
+
+marine_labels:
+  sql: |
+    SELECT cartodb_id, name, namealt, featurecla, the_geom_webmercator, scalerank FROM ne_marine_zoomed('!scale_denominator!',!bbox!) AS _
+
+admin1boundary_labels:
+  sql: |
+    SELECT cartodb_id, name, scalerank, the_geom_webmercator, geomtype from admin1boundaries_zoomed('planet_green','!scale_denominator!',!bbox!) as _
+
+admin1_labels:
+  sql: |
+    SELECT cartodb_id, name, scalerank, the_geom_webmercator FROM admin1_polygons_zoomed('!scale_denominator!',!bbox!) AS _
+
+continent_labels:
+  sql: |
+    SELECT cartodb_id, name, the_geom_webmercator FROM continents_zoomed('!scale_denominator!',!bbox!) AS _

--- a/layers.yml
+++ b/layers.yml
@@ -1,12 +1,3 @@
-toner:
-  type: http
-  urlTemplate: http://{s}.tile.stamen.com/toner/{z}/{x}/{y}.png
-  subdomains:
-    - a
-    - b
-    - c
-    - d
-
 global_variables:
   sql: |
     SELECT null::geometry AS the_geom_webmercator LIMIT 0

--- a/positron-all.yml
+++ b/positron-all.yml
@@ -1,155 +1,27 @@
-_layer_default: &layer
-  type: mapnik
-
-_options_default: &options
-  cartocss_version: 2.1.1
-
 name: Positron-all
-version: 0.0.1
-layergroup:
-  version: 1.0.1
-  minzoom: 0
-  maxzoom: 20
+minzoom: 0
+maxzoom: 20
 
-  layers:
-    # TODO merge options into layer to facilitate easier inclusion of external nodes
-    - <<: *layer
-      name: global_variables
-      options:
-        <<: *options
-        sql: |
-          SELECT null::geometry AS the_geom_webmercator LIMIT 0
-    - <<: *layer
-      name: false_background
-      options:
-        <<: *options
-        sql: |
-          SELECT the_geom_webmercator
-          FROM false_background_zoomed('!scale_denominator!', !bbox!) AS _
-    - <<: *layer
-      name: land_positive
-      options:
-        <<: *options
-        sql: |
-          SELECT
-            cartodb_id,
-            the_geom_webmercator
-          FROM land_positive_zoomed('!scale_denominator!', !bbox!) AS _
-    - <<: *layer
-      name: urban_areas
-      options:
-        <<: *options
-        sql: |
-          SELECT
-            cartodb_id,
-            scalerank,
-            the_geom_webmercator
-          FROM urban_areas_zoomed('!scale_denominator!',!bbox!) AS _
-    - <<: *layer
-      name: green_areas
-      options:
-        <<: *options
-        sql: |
-          SELECT osm_id, the_geom_webmercator, area FROM green_areas_zoomed('planet_green','!scale_denominator!',!bbox!) AS _
-    - <<: *layer
-      name: admin0boundaries
-      options:
-        <<: *options
-        sql: |
-          SELECT cartodb_id, the_geom_webmercator, unit FROM admin0boundaries_zoomed('planet_green','!scale_denominator!', !bbox!) AS _
-    - <<: *layer
-      name: admin1boundaries
-      options:
-        <<: *options
-        sql: |
-          SELECT cartodb_id, scalerank, the_geom_webmercator FROM admin1boundaries_zoomed('planet_green','!scale_denominator!', !bbox!) AS _
-    - <<: *layer
-      name: water
-      options:
-        <<: *options
-        sql: |
-          (SELECT id, the_geom_webmercator, name, type, is_lake, ne_scalerank, area FROM water_zoomed('planet_green','!scale_denominator!', !bbox!) AS _) UNION (SELECT cartodb_id, the_geom_webmercator, '' AS name, 'ocean' AS type, 1 AS is_lake, 0 AS ne_scalerank, 999999999 AS area FROM land_negative_zoomed('!scale_denominator!', !bbox!) AS _)
-    - <<: *layer
-      name: aeroways
-      options:
-        <<: *options
-        sql: |
-          SELECT osm_id, type, the_geom_webmercator FROM aeroways_zoomed('planet_green','!scale_denominator!', !bbox!) AS _
-    - <<: *layer
-      name: ne10mroads
-      options:
-        <<: *options
-        sql: |
-          SELECT cartodb_id, the_geom_webmercator, type, scalerank FROM ne_10m_roads_zoomed('!scale_denominator!', !bbox!) AS _
-    - <<: *layer
-      name: buildings
-      options:
-        <<: *options
-        sql: |
-          SELECT osm_id, the_geom_webmercator, area FROM buildings_zoomed('planet_green','!scale_denominator!',!bbox!) AS _
-    - <<: *layer
-      name: osmtunnels
-      options:
-        <<: *options
-        sql: |
-          select highway, railway, kind, the_geom_webmercator, is_link from tunnels('planet_green','!scale_denominator!',!bbox!) as _
-    - <<: *layer
-      name: osmroads
-      options:
-        <<: *options
-        sql: |
-          select highway, railway, kind, the_geom_webmercator, is_link from high_road('planet_green','!scale_denominator!',!bbox!) as _
-    - <<: *layer
-      name: osmbridges
-      options:
-        <<: *options
-        sql: |
-          select highway, railway, kind, the_geom_webmercator, is_link from bridges('planet_green','!scale_denominator!',!bbox!) as _
-    - <<: *layer
-      name: country_city_labels
-      options:
-        <<: *options
-        sql: |
-          SELECT cartodb_id, name, the_geom_webmercator, scalerank, place, pop_est, country_city, is_capital FROM country_city_labels_zoomed('planet_green','!scale_denominator!',!bbox!) AS _
-    - <<: *layer
-      name: park_labels
-      options:
-        <<: *options
-        sql: |
-          SELECT osm_id, name, area, the_geom_webmercator FROM green_areas_zoomed('planet_green','!scale_denominator!',!bbox!) AS _
-    - <<: *layer
-      name: water_labels
-      options:
-        <<: *options
-        sql: |
-          SELECT id, the_geom_webmercator, name, area, is_lake FROM water_zoomed('planet_green','!scale_denominator!',!bbox!) AS _
-    - <<: *layer
-      name: osm_roads_labels
-      options:
-        <<: *options
-        sql: |
-          SELECT name, highway, railway, kind, the_geom_webmercator FROM high_road_labels('planet_green','!scale_denominator!',!bbox!) as _
-    - <<: *layer
-      name: marine_labels
-      options:
-        <<: *options
-        sql: |
-          SELECT cartodb_id, name, namealt, featurecla, the_geom_webmercator, scalerank FROM ne_marine_zoomed('!scale_denominator!',!bbox!) AS _
-    - <<: *layer
-      name: admin1boundary_labels
-      options:
-        <<: *options
-        sql: |
-          SELECT cartodb_id, name, scalerank, the_geom_webmercator, geomtype from admin1boundaries_zoomed('planet_green','!scale_denominator!',!bbox!) as _
-    - <<: *layer
-      name: admin1_labels
-      options:
-        <<: *options
-        sql: |
-          SELECT cartodb_id, name, scalerank, the_geom_webmercator FROM admin1_polygons_zoomed('!scale_denominator!',!bbox!) AS _
-    - <<: *layer
-      name: continent_labels
-      options:
-        <<: *options
-        sql: |
-          SELECT cartodb_id, name, the_geom_webmercator FROM continents_zoomed('!scale_denominator!',!bbox!) AS _
+layers:
+  - global_variables:
+  - false_background:
+  - land_positive:
+  - urban_areas:
+  - green_areas:
+  - admin0boundaries:
+  - admin1boundaries:
+  - water:
+  - aeroways:
+  - ne10mroads:
+  - buildings:
+  - osmtunnels:
+  - osmroads:
+  - osmbridges:
+  - country_city_labels:
+  - park_labels:
+  - water_labels:
+  - osm_roads_labels:
+  - marine_labels:
+  - admin1boundary_labels:
+  - admin1_labels:
+  - continent_labels:

--- a/positron-labels-only.yml
+++ b/positron-labels-only.yml
@@ -1,70 +1,14 @@
-_layer_default: &layer
-  type: mapnik
-
-_options_default: &options
-  cartocss_version: 2.1.1
-
 name: Positron-labels-only
-version: 0.0.1
-layergroup:
-  version: 1.0.1
-  minzoom: 0
-  maxzoom: 20
+minzoom: 0
+maxzoom: 20
 
-  layers:
-    # TODO merge options into layer to facilitate easier inclusion of external nodes
-    - <<: *layer
-      name: global_variables
-      options:
-        <<: *options
-        cartocss_file: styles/global_variables_only_labels.mss
-        sql: |
-          SELECT null::geometry AS the_geom_webmercator LIMIT 0
-    - <<: *layer
-      name: country_city_labels
-      options:
-        <<: *options
-        sql: |
-          SELECT cartodb_id, name, the_geom_webmercator, scalerank, place, pop_est, country_city, is_capital FROM country_city_labels_zoomed('planet_green','!scale_denominator!',!bbox!) AS _
-    - <<: *layer
-      name: park_labels
-      options:
-        <<: *options
-        sql: |
-          SELECT osm_id, name, area, the_geom_webmercator FROM green_areas_zoomed('planet_green','!scale_denominator!',!bbox!) AS _
-    - <<: *layer
-      name: water_labels
-      options:
-        <<: *options
-        sql: |
-          SELECT id, the_geom_webmercator, name, area, is_lake FROM water_zoomed('planet_green','!scale_denominator!',!bbox!) AS _
-    - <<: *layer
-      name: osm_roads_labels
-      options:
-        <<: *options
-        sql: |
-          SELECT name, highway, railway, kind, the_geom_webmercator FROM high_road_labels('planet_green','!scale_denominator!',!bbox!) as _
-    - <<: *layer
-      name: marine_labels
-      options:
-        <<: *options
-        sql: |
-          SELECT cartodb_id, name, namealt, featurecla, the_geom_webmercator, scalerank FROM ne_marine_zoomed('!scale_denominator!',!bbox!) AS _
-    - <<: *layer
-      name: admin1boundary_labels
-      options:
-        <<: *options
-        sql: |
-          SELECT cartodb_id, name, scalerank, the_geom_webmercator, geomtype from admin1boundaries_zoomed('planet_green','!scale_denominator!',!bbox!) as _
-    - <<: *layer
-      name: admin1_labels
-      options:
-        <<: *options
-        sql: |
-          SELECT cartodb_id, name, scalerank, the_geom_webmercator FROM admin1_polygons_zoomed('!scale_denominator!',!bbox!) AS _
-    - <<: *layer
-      name: continent_labels
-      options:
-        <<: *options
-        sql: |
-          SELECT cartodb_id, name, the_geom_webmercator FROM continents_zoomed('!scale_denominator!',!bbox!) AS _
+layers:
+  - global_variables: styles/global_variables_only_labels.mss
+  - country_city_labels:
+  - park_labels:
+  - water_labels:
+  - osm_roads_labels:
+  - marine_labels:
+  - admin1boundary_labels:
+  - admin1_labels:
+  - continent_labels:

--- a/positron-no-labels.yml
+++ b/positron-no-labels.yml
@@ -1,107 +1,19 @@
-_layer_default: &layer
-  type: mapnik
-
-_options_default: &options
-  cartocss_version: 2.1.1
-
 name: Positron-no-labels
-version: 0.0.1
-layergroup:
-  version: 1.0.1
-  minzoom: 0
-  maxzoom: 20
+minzoom: 0
+maxzoom: 20
 
-  layers:
-    # TODO merge options into layer to facilitate easier inclusion of external nodes
-    - <<: *layer
-      name: global_variables
-      options:
-        <<: *options
-        sql: |
-          SELECT null::geometry AS the_geom_webmercator LIMIT 0
-    - <<: *layer
-      name: false_background
-      options:
-        <<: *options
-        sql: |
-          SELECT the_geom_webmercator
-          FROM false_background_zoomed('!scale_denominator!', !bbox!) AS _
-    - <<: *layer
-      name: land_positive
-      options:
-        <<: *options
-        sql: |
-          SELECT
-            cartodb_id,
-            the_geom_webmercator
-          FROM land_positive_zoomed('!scale_denominator!', !bbox!) AS _
-    - <<: *layer
-      name: urban_areas
-      options:
-        <<: *options
-        sql: |
-          SELECT
-            cartodb_id,
-            scalerank,
-            the_geom_webmercator
-          FROM urban_areas_zoomed('!scale_denominator!',!bbox!) AS _
-    - <<: *layer
-      name: green_areas
-      options:
-        <<: *options
-        sql: |
-          SELECT osm_id, the_geom_webmercator, area FROM green_areas_zoomed('planet_green','!scale_denominator!',!bbox!) AS _
-    - <<: *layer
-      name: admin0boundaries
-      options:
-        <<: *options
-        sql: |
-          SELECT cartodb_id, the_geom_webmercator, unit FROM admin0boundaries_zoomed('planet_green','!scale_denominator!', !bbox!) AS _
-    - <<: *layer
-      name: admin1boundaries
-      options:
-        <<: *options
-        sql: |
-          SELECT cartodb_id, scalerank, the_geom_webmercator FROM admin1boundaries_zoomed('planet_green','!scale_denominator!', !bbox!) AS _
-    - <<: *layer
-      name: water
-      options:
-        <<: *options
-        sql: |
-          (SELECT id, the_geom_webmercator, name, type, is_lake, ne_scalerank, area FROM water_zoomed('planet_green','!scale_denominator!', !bbox!) AS _) UNION (SELECT cartodb_id, the_geom_webmercator, '' AS name, 'ocean' AS type, 1 AS is_lake, 0 AS ne_scalerank, 999999999 AS area FROM land_negative_zoomed('!scale_denominator!', !bbox!) AS _)
-    - <<: *layer
-      name: aeroways
-      options:
-        <<: *options
-        sql: |
-          SELECT osm_id, type, the_geom_webmercator FROM aeroways_zoomed('planet_green','!scale_denominator!', !bbox!) AS _
-    - <<: *layer
-      name: ne10mroads
-      options:
-        <<: *options
-        sql: |
-          SELECT cartodb_id, the_geom_webmercator, type, scalerank FROM ne_10m_roads_zoomed('!scale_denominator!', !bbox!) AS _
-    - <<: *layer
-      name: buildings
-      options:
-        <<: *options
-        sql: |
-          SELECT osm_id, the_geom_webmercator, area FROM buildings_zoomed('planet_green','!scale_denominator!',!bbox!) AS _
-    - <<: *layer
-      name: osmtunnels
-      options:
-        <<: *options
-        sql: |
-          select highway, railway, kind, the_geom_webmercator, is_link from tunnels('planet_green','!scale_denominator!',!bbox!) as _
-    - <<: *layer
-      name: osmroads
-      options:
-        <<: *options
-        sql: |
-          select highway, railway, kind, the_geom_webmercator, is_link from high_road('planet_green','!scale_denominator!',!bbox!) as _
-    - <<: *layer
-      name: osmbridges
-      options:
-        <<: *options
-        sql: |
-          select highway, railway, kind, the_geom_webmercator, is_link from bridges('planet_green','!scale_denominator!',!bbox!) as _
+layers:
+  - global_variables:
+  - false_background:
+  - land_positive:
+  - urban_areas:
+  - green_areas:
+  - admin0boundaries:
+  - admin1boundaries:
+  - water:
+  - aeroways:
+  - ne10mroads:
+  - buildings:
+  - osmtunnels:
+  - osmroads:
+  - osmbridges:

--- a/positron.yml
+++ b/positron.yml
@@ -1,140 +1,24 @@
-_layer_default: &layer
-  type: mapnik
-
-_options_default: &options
-  cartocss_version: 2.1.1
-
 name: Positron
-version: 0.0.1
-placeholders:
-  color:
-    type: css_color
-    default: red
-  cartodb_id:
-    type: number
-    default: 1
-layergroup:
-  version: 1.0.1
-  minzoom: 0
-  maxzoom: 20
+minzoom: 0
+maxzoom: 20
 
-  layers:
-    # TODO merge options into layer to facilitate easier inclusion of external nodes
-    - <<: *layer
-      name: global_variables
-      options:
-        <<: *options
-        sql: |
-          SELECT null::geometry AS the_geom_webmercator LIMIT 0
-    - <<: *layer
-      name: false_background
-      options:
-        <<: *options
-        sql: |
-          SELECT the_geom_webmercator
-          FROM false_background_zoomed('!scale_denominator!', !bbox!) AS _
-    - <<: *layer
-      name: land_positive
-      options:
-        <<: *options
-        sql: |
-          SELECT
-            cartodb_id,
-            the_geom_webmercator
-          FROM land_positive_zoomed('!scale_denominator!', !bbox!) AS _
-    - <<: *layer
-      name: admin0boundaries
-      options:
-        <<: *options
-        sql: |
-          SELECT cartodb_id, the_geom_webmercator, unit FROM admin0boundaries_zoomed('planet_green','!scale_denominator!', !bbox!) AS _
-    - <<: *layer
-      name: admin1boundaries
-      options:
-        <<: *options
-        sql: |
-          SELECT cartodb_id, scalerank, the_geom_webmercator FROM admin1boundaries_zoomed('planet_green','!scale_denominator!', !bbox!) AS _
-    - <<: *layer
-      name: water
-      options:
-        <<: *options
-        sql: |
-          (SELECT id, the_geom_webmercator, name, type, is_lake, ne_scalerank, area FROM water_zoomed('planet_green','!scale_denominator!', !bbox!) AS _) UNION (SELECT cartodb_id, the_geom_webmercator, '' AS name, 'ocean' AS type, 1 AS is_lake, 0 AS ne_scalerank, 999999999 AS area FROM land_negative_zoomed('!scale_denominator!', !bbox!) AS _)
-    - <<: *layer
-      name: aeroways
-      options:
-        <<: *options
-        sql: |
-          SELECT osm_id, type, the_geom_webmercator FROM aeroways_zoomed('planet_green','!scale_denominator!', !bbox!) AS _
-    - <<: *layer
-      name: ne10mroads
-      options:
-        <<: *options
-        sql: |
-          SELECT cartodb_id, the_geom_webmercator, type, scalerank FROM ne_10m_roads_zoomed('!scale_denominator!', !bbox!) AS _
-    - <<: *layer
-      name: osmtunnels
-      options:
-        <<: *options
-        sql: |
-          select highway, railway, kind, the_geom_webmercator, is_link from tunnels('planet_green','!scale_denominator!',!bbox!) as _
-    - <<: *layer
-      name: osmroads
-      options:
-        <<: *options
-        sql: |
-          select highway, railway, kind, the_geom_webmercator, is_link from high_road('planet_green','!scale_denominator!',!bbox!) as _
-    - <<: *layer
-      name: osmbridges
-      options:
-        <<: *options
-        sql: |
-          select highway, railway, kind, the_geom_webmercator, is_link from bridges('planet_green','!scale_denominator!',!bbox!) as _
-    - <<: *layer
-      name: country_city_labels
-      options:
-        <<: *options
-        sql: |
-          SELECT cartodb_id, name, the_geom_webmercator, scalerank, place, pop_est, country_city, is_capital FROM country_city_labels_zoomed('planet_green','!scale_denominator!',!bbox!) AS _
-    - <<: *layer
-      name: park_labels
-      options:
-        <<: *options
-        sql: |
-          SELECT osm_id, name, area, the_geom_webmercator FROM green_areas_zoomed('planet_green','!scale_denominator!',!bbox!) AS _
-    - <<: *layer
-      name: water_labels
-      options:
-        <<: *options
-        sql: |
-          SELECT id, the_geom_webmercator, name, area, is_lake FROM water_zoomed('planet_green','!scale_denominator!',!bbox!) AS _
-    - <<: *layer
-      name: osm_roads_labels
-      options:
-        <<: *options
-        sql: |
-          SELECT name, highway, railway, kind, the_geom_webmercator FROM high_road_labels('planet_green','!scale_denominator!',!bbox!) as _
-    - <<: *layer
-      name: marine_labels
-      options:
-        <<: *options
-        sql: |
-          SELECT cartodb_id, name, namealt, featurecla, the_geom_webmercator, scalerank FROM ne_marine_zoomed('!scale_denominator!',!bbox!) AS _
-    - <<: *layer
-      name: admin1boundary_labels
-      options:
-        <<: *options
-        sql: |
-          SELECT cartodb_id, name, scalerank, the_geom_webmercator, geomtype from admin1boundaries_zoomed('planet_green','!scale_denominator!',!bbox!) as _
-    - <<: *layer
-      name: admin1_labels
-      options:
-        <<: *options
-        sql: |
-          SELECT cartodb_id, name, scalerank, the_geom_webmercator FROM admin1_polygons_zoomed('!scale_denominator!',!bbox!) AS _
-    - <<: *layer
-      name: continent_labels
-      options:
-        <<: *options
-        sql: |
-          SELECT cartodb_id, name, the_geom_webmercator FROM continents_zoomed('!scale_denominator!',!bbox!) AS _
+layers:
+  - global_variables:
+  - false_background:
+  - land_positive:
+  - admin0boundaries:
+  - admin1boundaries:
+  - water:
+  - aeroways:
+  - ne10mroads:
+  - osmtunnels:
+  - osmroads:
+  - osmbridges:
+  - country_city_labels:
+  - park_labels:
+  - water_labels:
+  - osm_roads_labels:
+  - marine_labels:
+  - admin1boundary_labels:
+  - admin1_labels:
+  - continent_labels:


### PR DESCRIPTION
Extract common layer definitions into `layers.yml` (the "layer catalog") and change the project file format to support references + overloading.
